### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ yarn start
 4. Install NPM, Yarn
 
 # Build Smart Contract (compiled for BPF)
+Run the following from the program/ subdirectory:
 
 ```bash
 $ cargo build-bpf


### PR DESCRIPTION
If you run "cargo build-bpf" from the root directory, you get an error such as the following:

Failed to obtain package metadata: Error during execution of `cargo metadata`: error:
could not find `Cargo.toml` in `/home/gabe/code/dapp-scalfold` or any parent directory

Seems these commands need to be run from the program subdirectory.