### PR TITLE
implement program test rather than using TestValidator

### DIFF
--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -5,7 +5,7 @@ use solana_program::{
 solana_program::declare_id!("BpfProgram1111111111111111111111111111111111");
 
 entrypoint!(process_instruction);
-fn process_instruction(
+pub fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
     instruction_data: &[u8],
@@ -17,40 +17,4 @@ fn process_instruction(
         instruction_data
     );
     Ok(())
-}
-
-#[cfg(test)]
-mod test {
-    use {
-        super::*,
-        assert_matches::*,
-        solana_program::instruction::{AccountMeta, Instruction},
-        solana_program_test::*,
-        solana_sdk::{signature::Signer, transaction::Transaction},
-    };
-
-    #[tokio::test]
-    async fn test_transaction() {
-        let program_id = Pubkey::new_unique();
-
-        let (mut banks_client, payer, recent_blockhash) = ProgramTest::new(
-            "bpf_program_template",
-            program_id,
-            processor!(process_instruction),
-        )
-        .start()
-        .await;
-
-        let mut transaction = Transaction::new_with_payer(
-            &[Instruction {
-                program_id,
-                accounts: vec![AccountMeta::new(payer.pubkey(), false)],
-                data: vec![1, 2, 3],
-            }],
-            Some(&payer.pubkey()),
-        );
-        transaction.sign(&[&payer], recent_blockhash);
-
-        assert_matches!(banks_client.process_transaction(transaction).await, Ok(()));
-    }
 }


### PR DESCRIPTION
Fixes #14 in which i broke `cargo test-bpf`

This also guide to the good practice of using `ProgramTest` early and use it with `cargo test` and `cargo test-bpf`

It is also better for newcomers to learn a single way, rather than two ways to pretty much do the same thing. Is there any advantage in using the `TestValidator` struct?