### PR TITLE
chore: update solana download url to latest version 1.7.12

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,7 @@ image:
   file: .gitpod.Dockerfile
 tasks:
   - init: |
-      sh -c "$(curl -sSfL https://release.solana.com/v1.6.12/install)"
+      sh -c "$(curl -sSfL https://release.solana.com/v1.7.12/install)"
       export PATH=~/.local/share/solana/install/active_release/bin:$PATH
     command: |
       rustup toolchain link bpf node_modules/@solana/web3.js/bpf-sdk/dependencies/rust-bpf


### PR DESCRIPTION
Updates .gitpod.yml Solana install url from version 1.6.12 to 1.7.12