### PR TITLE
Fix app crash on first launch

### DIFF
--- a/src/contexts/accounts.tsx
+++ b/src/contexts/accounts.tsx
@@ -155,7 +155,6 @@ export const cache = {
     let account;
     try {
       account = deserialize(new PublicKey(address), obj);
-
     } catch(e) {
       console.error(e);
     }

--- a/src/contexts/accounts.tsx
+++ b/src/contexts/accounts.tsx
@@ -152,7 +152,13 @@ export const cache = {
 
     cache.registerParser(id, deserialize);
     pendingCalls.delete(address);
-    const account = deserialize(new PublicKey(address), obj);
+    let account;
+    try {
+      account = deserialize(new PublicKey(address), obj);
+
+    } catch(e) {
+      console.error(e);
+    }
     if (!account) {
       return;
     }


### PR DESCRIPTION
On first install, app crashes with `not valid mint`. Issue #23