### PR TITLE
fix: solana embed in nextjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@solana/wallet-adapter-wallets": "^0.15.3",
     "@solana/web3.js": "^1.31.0",
     "@tailwindcss/typography": "^0.5.0",
+    "@toruslabs/solana-embed": "0.1.5",
     "daisyui": "^1.24.3",
     "immer": "^9.0.12",
     "next": "12.0.8",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,21 @@
 import type { NextPage } from "next";
 import Head from "next/head";
 import { HomeView } from "../views";
+// import Torus from "@toruslabs/solana-embed";
+import { useEffect } from "react";
 
 const Home: NextPage = (props) => {
+  useEffect(()=>{
+    const init = async () => {
+        const Torus = (await import("@toruslabs/solana-embed")).default
+        console.log(Torus)
+        let torus = new Torus({})
+        await torus.init()
+        
+        await torus.login()
+    }
+    init();
+  },[])
   return (
     <div>
       <Head>
@@ -11,7 +24,8 @@ const Home: NextPage = (props) => {
           name="description"
           content="Solana Scaffold"
         />
-      </Head>
+      </Head>    
+
       <HomeView />
     </div>
   );


### PR DESCRIPTION
We tried Solana-embed with `is-stream 2.0.0`
although the ESM error went away, new error such as `Window is undefined` appear.

Solana Embed is not able to SSR-ed using Nextjs.

Suggestion workaround for NextJs is to load dynamically like in this PR