### PR TITLE
Transaction leaves an account with a lower balance than rent-exempt minimum

### DIFF
--- a/src/components/SendTransaction.tsx
+++ b/src/components/SendTransaction.tsx
@@ -20,7 +20,7 @@ export const SendTransaction: FC = () => {
                 SystemProgram.transfer({
                     fromPubkey: publicKey,
                     toPubkey: Keypair.generate().publicKey,
-                    lamports: 1,
+                    lamports: 1_000_000,
                 })
             );
 


### PR DESCRIPTION
Fixed the same way as in the cookbook: https://github.com/solana-developers/solana-cookbook/pull/355

Since feature BkFDxiJQWZXGTZaJQxH7wVEHkAmwCgSEVkrvswFfRJPD, new accounts are required to be rent-exempt.

```
solana rent 0
```
Rent-exempt minimum: 0.00089088 SOL

**Error:**
https://github.com/solana-labs/solana/blob/f81c5df1f02b0e41f3e5dd3d236a34818cc40a5a/sdk/src/transaction/error.rs

**Related issues:**
https://github.com/solana-labs/dapp-scaffold/issues/173
https://github.com/solana-labs/dapp-scaffold/issues/178

