### PR TITLE
Enable NufiWalletAdapter by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@solana/wallet-adapter-base": "^0.9.3",
     "@solana/wallet-adapter-react": "^0.15.3",
     "@solana/wallet-adapter-react-ui": "^0.9.5",
-    "@solana/wallet-adapter-wallets": "^0.15.3",
+    "@solana/wallet-adapter-wallets": "^0.16.6",
     "@solana/web3.js": "^1.31.0",
     "@tailwindcss/typography": "^0.5.0",
     "daisyui": "^1.24.3",

--- a/src/contexts/ContextProvider.tsx
+++ b/src/contexts/ContextProvider.tsx
@@ -2,6 +2,7 @@ import { WalletAdapterNetwork, WalletError } from '@solana/wallet-adapter-base';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
 import { WalletModalProvider as ReactUIWalletModalProvider } from '@solana/wallet-adapter-react-ui';
 import {
+    NufiWalletAdapter,
     PhantomWalletAdapter,
     SolflareWalletAdapter,
     SolletExtensionWalletAdapter,
@@ -31,6 +32,7 @@ const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
             new SolletWalletAdapter({ network }),
             new SolletExtensionWalletAdapter({ network }),
             new TorusWalletAdapter(),
+            new NufiWalletAdapter(),
             // new LedgerWalletAdapter(),
             // new SlopeWalletAdapter(),
         ],


### PR DESCRIPTION
This is a simple convenience change.

We use `dapp-scaffold` for both manual and automated testing of our extension. It's a bit of an inconvenience to carry around a patch like this everywhere, and it would make things easier if something like this could be added upstream.

Thanks in advance!