### PR TITLE
fix footer gap on basics page

### DIFF
--- a/src/components/ContentContainer.tsx
+++ b/src/components/ContentContainer.tsx
@@ -9,9 +9,9 @@ interface Props {
 export const ContentContainer: React.FC<Props> = ({ children }) => {
 
   return (
-    <div className="flex-1 drawer h-52">
+    <div className="flex-1 drawer h-52 flex-col justify-between">
       <input id="my-drawer" type="checkbox" className="grow drawer-toggle" />
-      <div className="items-center  drawer-content">
+      <div className="items-center drawer-content flex flex-col justify-between">
         {children}
       </div>
       {/* SideBar / Drawer */}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,8 +3,8 @@ import Link from 'next/link';
 import Image from 'next/image';
 export const Footer: FC = () => {
     return (
-        <div className="relative mb-40 mt-40">
-            <footer className="border-t-2 border-[#141414] bg-black hover:text-white absolute w-full" >
+        <div className="flex">
+            <footer className="border-t-2 border-[#141414] bg-black hover:text-white w-screen" >
                 <div className="ml-12 py-12 mr-12">
                     <div className="grid grid-cols-2 md:grid-cols-6 gap-2 md:gap-8 md:space-x-12 relative">
                         <div className='flex flex-col col-span-2 mx-4 items-center md:items-start'>


### PR DESCRIPTION
Fixed the gap between the footer and the bottom of the page on the Basics page.

Before:
![image](https://github.com/solana-labs/dapp-scaffold/assets/116292851/2fd70df2-ad8b-40d5-ad05-edc17a1d5ef6)

After:
![image](https://github.com/solana-labs/dapp-scaffold/assets/116292851/c9318073-d91c-493e-846a-04e2566b189e)
