### PR TITLE
Remove plugin date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@solana/web3.js": "^1.73.0",
     "@tailwindcss/typography": "^0.5.9",
     "daisyui": "^1.24.3",
-    "date-fns": "^2.29.3",
+    "dayjs": "^1.11.10",
     "immer": "^9.0.12",
     "next": "^13.1.5",
     "next-compose-plugins": "^2.2.1",

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -1,9 +1,9 @@
-import { format } from 'date-fns';
+import dayjs from 'dayjs';
 
 // Concatenates classes into a single className string
 const cn = (...args: string[]) => args.join(' ');
 
-const formatDate = (date: string) => format(new Date(date), 'MM/dd/yyyy h:mm:ss');
+const formatDate = (date: string) => dayjs(date).format('MM/dd/yyyy h:mm:ss');
 
 /**
  * Formats number as currency string.


### PR DESCRIPTION
The date-fns plugin has firebase as a dependency. Which represents a risk factor for projects.
In place of date-fns I included dayjs. In addition to being safer, it is much faster.

![image](https://github.com/solana-labs/dapp-scaffold/assets/8239030/c1f303bb-0bc3-46e4-bd3c-31512e39b42a)

Attached is what date-fns includes in the project.
![Screenshot_17](https://github.com/solana-labs/dapp-scaffold/assets/8239030/77b502f1-af40-4115-857a-271152648596)
